### PR TITLE
Show fund allocation item name instead of category group

### DIFF
--- a/resources/views/fund-views/163.blade.php
+++ b/resources/views/fund-views/163.blade.php
@@ -187,7 +187,7 @@
                             @else
                                 @forelse($fund_allocation as $item)
                                     <tr>
-                                        <td class="border border-black px-2">{{ $item->categoryGroup?->name }}</td>
+                                        <td class="border border-black px-2">{{ $item->name }}</td>
                                         <td class="border border-black px-2">
                                             @if ($is_q1 && in_array($activeButton, ['sksuPre', 'sksuPpmp163', 'accessPpmp163', 'generate163PerCampus']))
                                                 <div class="flex justify-between">

--- a/resources/views/fund-views/164MF.blade.php
+++ b/resources/views/fund-views/164MF.blade.php
@@ -180,7 +180,7 @@
                             @else
                                 @forelse($fund_allocation as $item)
                                     <tr>
-                                        <td class="border border-black px-2">{{ $item->categoryGroup?->name }}</td>
+                                        <td class="border border-black px-2">{{ $item->name }}</td>
                                         <td class="border border-black px-2">
                                             @if ($is_q1 && in_array($activeButton, ['sksuPre', 'generateSksuppmp', 'generateSksuppmpPerCostCenterMfo']))
                                                 <div class="flex justify-between">

--- a/resources/views/fund-views/164OSF.blade.php
+++ b/resources/views/fund-views/164OSF.blade.php
@@ -180,7 +180,7 @@
                             @else
                                 @forelse($fund_allocation as $item)
                                     <tr>
-                                        <td class="border border-black px-2">{{ $item->categoryGroup?->name }}</td>
+                                        <td class="border border-black px-2">{{ $item->name }}</td>
                                         <td class="border border-black px-2">
                                             @if ($is_q1 && in_array($activeButton, ['sksuPre', 'generateSksuppmp', 'generateSksuppmpPerCostCenterMfo']))
                                                 <div class="flex justify-between">

--- a/resources/views/fund-views/164T.blade.php
+++ b/resources/views/fund-views/164T.blade.php
@@ -165,8 +165,7 @@
                                             <td class="border border-black px-2">
                                                 <div class="flex justify-between">
                                                     <span> {{ $mergedDetail['budget_name'] }}</span>
-                                                    {{-- <span>₱
-                                        {{ number_format($mergedDetail['total_budget_per_uacs'], 2) }}</span> --}}
+
                                                 </div>
 
                                             </td>
@@ -189,7 +188,7 @@
                                 @else
                                     @forelse($fund_allocation as $item)
                                         <tr>
-                                            <td class="border border-black px-2">{{ $item->categoryGroup?->name }}</td>
+                                            <td class="border border-black px-2">{{ $item->name }}</td>
                                             <td class="border border-black px-2">
                                                 @if ($is_q1 && in_array($activeButton, ['sksuPre', 'generateSksuppmp', 'generateSksuppmpPerCostCenterMfo']))
                                                     <div class="flex justify-between">
@@ -298,24 +297,6 @@
                                                     </div>
                                                 @endif
                                             </td>
-                                            {{-- <td class="border border-black px-2">
-                                @foreach ($ppmp_details->where('mfo_fee_id', $item->mfo_fee_id) as $ppmp)
-                                <ul>
-                                    <li>
-                                        {{$ppmp->uacs}}
-                                    </li>
-                                </ul>
-                                @endforeach
-                            </td>
-                            <td class="border border-black px-2">
-                                @foreach ($ppmp_details->where('mfo_fee_id', $item->mfo_fee_id) as $ppmp)
-                                <ul>
-                                    <li>
-                                        {{$ppmp->budget_name}}
-                                    </li>
-                                </ul>
-                                @endforeach
-                            </td> --}}
                                         </tr>
                                     @empty
                                         <tr>
@@ -408,38 +389,6 @@
                         </table>
 
 
-                        {{-- <table class="w-full mt-4">
-                    <thead>
-                        <tr>
-                            <th class="border border-black">UACS Code</th>
-                            <th class="border border-black">Account Title</th>
-                            <th class="border border-black">Total</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @forelse($ppmp_details as $item)
-                        <tr>
-                            <td class="border border-black px-2">{{$item->categoryItem?->uacs_code}}</td>
-                            <td class="border border-black px-2">{{$item->categoryItem?->name}}</td>
-                            <td class="border border-black text-right px-2">₱ {{number_format($item->total_budget, 2)}}
-                            </td>
-                        </tr>
-                        @empty
-                        <tr>
-                            <td class="border border-black text-center py-3 italic" colspan="3">No data available</td>
-                        </tr>
-                        @endforelse
-                    </tbody>
-                    <tr>
-                        <td class="border border-black text-left font-semibold p-1" colspan="2">Grand Total</td>
-                        <td class="border border-black text-right font-semibold px-2">
-                            <div class="flex justify-between">
-                                <span>₱</span>
-                                <span>{{$total === null ? 0 : number_format($total->total_budget, 2)}}</span>
-                            </div>
-                        </td>
-                    </tr>
-                </table> --}}
                     </div>
                     {{-- signatories --}}
                     @php

--- a/resources/views/fund-views/164TNonFHE.blade.php
+++ b/resources/views/fund-views/164TNonFHE.blade.php
@@ -180,7 +180,7 @@
                             @else
                                 @forelse($fund_allocation as $item)
                                     <tr>
-                                        <td class="border border-black px-2">{{ $item->categoryGroup?->name }}</td>
+                                        <td class="border border-black px-2">{{ $item->name }}</td>
                                         <td class="border border-black px-2">
                                             @if ($is_q1 && in_array($activeButton, ['sksuPre', 'generateSksuppmp', 'generateSksuppmpPerCostCenterMfo']))
                                                 <div class="flex justify-between">


### PR DESCRIPTION
Updated fund allocation tables in multiple fund view Blade templates to display the item's name directly, replacing the previous use of the category group name. Also removed commented-out legacy code from 164T.blade.php for clarity.