### PR TITLE
Update fund allocation table to use item name

### DIFF
--- a/resources/views/exports/101.blade.php
+++ b/resources/views/exports/101.blade.php
@@ -62,7 +62,7 @@
         </thead>
         @forelse($fund_allocation as $item)
             <tr>
-                <td class="border border-black px-2">{{ $item->categoryGroup?->name }}</td>
+                <td class="border border-black px-2">{{ $item->name }}</td>
                 <td class="border border-black px-2">
                     @if (
                         $is_q1 &&

--- a/resources/views/exports/164T.blade.php
+++ b/resources/views/exports/164T.blade.php
@@ -71,7 +71,6 @@
                         <td class="border border-black px-2">Total Receipts</td>
                         <td class="border border-black px-2">
                             <div class="flex justify-between">
-
                                 <span>{{ number_format($fund_allocation->sum('total_allocated'), 2) }}</span>
                             </div>
                         </td>
@@ -87,7 +86,6 @@
                                 ]))
                             <td class="border border-black px-2">
                                 <div class="flex justify-between">
-
                                     <span>{{ number_format(
                                         $non_supplemental_fund_allocation->sum('total_allocated') - $non_supplemental_total_programmed->total_budget,
                                         2,
@@ -151,7 +149,7 @@
         @else
             @forelse($fund_allocation as $item)
                 <tr>
-                    <td class="border border-black px-2">{{ $item->categoryGroup?->name }}</td>
+                    <td class="border border-black px-2">{{ $item->name }}</td>
                     <td class="border border-black px-2">
                         @if (
                             $is_q1 &&


### PR DESCRIPTION
Replaced usage of $item->categoryGroup?->name with $item->name in both 101.blade.php and 164T.blade.php export views to display the correct fund allocation name. Also removed unnecessary blank lines in 164T.blade.php for cleaner formatting.